### PR TITLE
position:relative for pb-view

### DIFF
--- a/resources/css/theme.css
+++ b/resources/css/theme.css
@@ -234,6 +234,7 @@ pb-view {
     font-family: var(--pb-content-font-family);
     font-size: var(--pb-content-font-size);
     margin: 0 16px;
+    position:relative;
 }
 
 .breadcrumbs pb-view {


### PR DESCRIPTION
this is crucial for absolutely or statically positioned elements within <pb-view> elements like e.g. <pb-popover>