### PR TITLE
Normalize the spelling of "organization"

### DIFF
--- a/data/doc/documentation.xml
+++ b/data/doc/documentation.xml
@@ -8347,7 +8347,7 @@ import module namespace docbook-nav="http://www.tei-c.org/tei-simple/navigation/
             <listitem>
               <para><link xlink:href="https://gnd.network/">Gemeinsame Normdatei</link> via <link
                   xlink:href="http://lobid.org/"
-                >lobid.org</link> - for people, organisations and terms</para>
+                >lobid.org</link> - for people, organizations and terms</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -8368,7 +8368,7 @@ import module namespace docbook-nav="http://www.tei-c.org/tei-simple/navigation/
             <listitem>
               <para><link
                   xlink:href="https://theologie.unibas.ch/de/karl-barth-zentrum/gesamtausgabe/"
-                  >Karl Barth Gesamtausgabe</link> - for people, organisations, terms, abbreviations</para>
+                  >Karl Barth Gesamtausgabe</link> - for people, organizations, terms, abbreviations</para>
             </listitem>
           </varlistentry>
           <varlistentry>
@@ -8381,7 +8381,7 @@ import module namespace docbook-nav="http://www.tei-c.org/tei-simple/navigation/
       <para>Which authority is used for which annotation type can be configured in the HTML template defining the user interface of the annotations editor. It resides in the file <filename>templates/pages/annotate.html</filename> and can be changed in eXide (or any editor of your choice). A simple configuration looks as follows:</para>
       <programlisting language="xml" xml:space="preserve"><![CDATA[
 <pb-authority-lookup subscribe="transcription" emit="transcription">
-    <pb-authority connector="GND" name="organisation" prefix="gnd"></pb-authority>
+    <pb-authority connector="GND" name="organization" prefix="gnd"></pb-authority>
     <pb-authority connector="GeoNames" name="place" user="existdb" prefix="geo"></pb-authority>
     <pb-authority connector="GND" name="term" prefix="gnd"></pb-authority>
     <pb-authority connector="GND" name="person" prefix="gnd"></pb-authority>

--- a/data/doc/documentation.xml
+++ b/data/doc/documentation.xml
@@ -8084,7 +8084,7 @@ import module namespace docbook-nav="http://www.tei-c.org/tei-simple/navigation/
         you can use the <emphasis>corr</emphasis> or <emphasis>reg</emphasis> annotation type, which corresponds to the TEI encoding with choice/sic/corr or choice/orig/reg.
       </para>
       <para>You can use annotations for virtually any kind of inline markup. The only strict requirement is that the <emphasis>base text</emphasis>, our source document,
-        remains stable <emphasis>during an editing session</emphasis> i.e. until annotations are merged. Reason for that is the annotations are anchored to a 
+        remains stable <emphasis>during an editing session</emphasis> i.e. until annotations are merged. The reason for that is the annotations are anchored to a 
         certain position in the document, so any changes to it would mean that our coordinates might suddenly point to different fragments.</para>
       <para>That said, there's also a special <emphasis>edit</emphasis> annotation type, which will just "seamlessly" change the transcription text fragment 
         without adding any explicit markup. Nevertheless, such a change to the TEI document is only applied when you merge and therefore 
@@ -8210,7 +8210,7 @@ import module namespace docbook-nav="http://www.tei-c.org/tei-simple/navigation/
       <para>Toggle annotations are immediately applied when you click the annotation button. Since they do not require any further input they are just simply applied without much ado.
         Some good candidates might be titles or deletions.
       </para>
-      <para>It is worth noting that it's not a textual fenomenon that constitutes a <emphasis>toggle</emphasis> annotation 
+      <para>It is worth noting that it's not a textual phenomenon that constitutes a <emphasis>toggle</emphasis> annotation 
         versus <emphasis>semantic</emphasis> or <emphasis>analytic</emphasis> in our simple category scheme. It is rather what kinds of detail a particular project
         decides to encode or not. Encoding of titles can be a <emphasis>toggle</emphasis> if we just decide to simply say that a text fragment is a title. It could become a
         <emphasis>semantic</emphasis> annotation if we'd like to associate it with a bibliographical reference or other detailed information.

--- a/modules/annotation-config.xqm
+++ b/modules/annotation-config.xqm
@@ -20,7 +20,7 @@ declare function anno:annotations($type as xs:string, $properties as map(*), $co
             <placeName xmlns="http://www.tei-c.org/ns/1.0" ref="{$properties?ref}">{$content()}</placeName>
         case "term" return
             <term xmlns="http://www.tei-c.org/ns/1.0" ref="{$properties?ref}">{$content()}</term>
-        case "organisation" return
+        case "organization" return
             <orgName xmlns="http://www.tei-c.org/ns/1.0" ref="{$properties?ref}">{$content()}</orgName>
         case "hi" return
             <hi xmlns="http://www.tei-c.org/ns/1.0">
@@ -81,7 +81,7 @@ declare function anno:occurrences($type as xs:string, $key as xs:string) {
             collection($config:data-default)//tei:placeName[@ref = $key]
         case "term" return
             collection($config:data-default)//tei:term[@ref = $key]
-        case "organisation" return
+        case "organization" return
             collection($config:data-default)//tei:orgName[@ref = $key]
          default return ()
 };
@@ -136,7 +136,7 @@ declare function anno:create-record($type as xs:string, $id as xs:string, $data 
                         ()
                 }
             </person>
-        case "organisation" return
+        case "organization" return
             <org xmlns="http://www.tei-c.org/ns/1.0" xml:id="{$id}">
                 <orgName type="full">{$data?name}</orgName>
             </org>
@@ -172,7 +172,7 @@ declare function anno:query($type as xs:string, $query as xs:string?) {
                         "details": ``[`{$person/tei:note/string()}` - `{$person/tei:country/string()}`, `{$person/tei:region/string()}`]``,
                         "link": $person/tei:ptr/@target/string()
                     }
-            case "organisation" return
+            case "organization" return
                 for $org in doc($anno:local-authority-file)//tei:org[ft:query(tei:orgName, $query)]
                 return
                     map {
@@ -203,7 +203,7 @@ declare function anno:insert-point($type as xs:string) {
     switch ($type)
         case "place" return
             doc($anno:local-authority-file)//tei:listPlace
-        case "organisation" return
+        case "organization" return
             doc($anno:local-authority-file)//tei:listOrg
         case "term" return
             doc($anno:local-authority-file)//tei:taxonomy
@@ -218,7 +218,7 @@ declare function anno:insert-point($type as xs:string) {
 declare function anno:local-search-strings($type as xs:string, $entry as element()?) {
     switch($type)
         case "place" return $entry/tei:placeName/string()
-        case "organisation" return $entry/tei:orgName/string()
+        case "organization" return $entry/tei:orgName/string()
         case "term" return $entry/tei:catDesc/string()
         default return $entry/tei:persName/string()
 };

--- a/odd/annotations.odd
+++ b/odd/annotations.odd
@@ -75,7 +75,7 @@
                     </model>
                 </elementSpec>
                 <elementSpec ident="orgName" mode="add">
-                    <model behaviour="inline" cssClass="annotation annotation-organisation"/>
+                    <model behaviour="inline" cssClass="annotation annotation-organization"/>
                 </elementSpec>
                 <elementSpec ident="place" mode="add">
                     <modelSequence>

--- a/odd/tei_simplePrint.odd
+++ b/odd/tei_simplePrint.odd
@@ -856,7 +856,7 @@ live without God in the world, and only mind earthly things.
             images represent double page spreads, or where there are multiple images of the same
             page (for example at different resolutions). </p>
           <p>A more powerful approach, discussed in section <ptr target="#Simple-fax"/> below, is to
-            use the <gi>facsimile</gi> element to define the organisation of the set of images
+            use the <gi>facsimile</gi> element to define the organization of the set of images
             representing the text, and then use the <att>facs</att> attribute to point to individual
             components of that representation. </p>
         </div>

--- a/templates/basic/modules/config.xqm
+++ b/templates/basic/modules/config.xqm
@@ -351,7 +351,7 @@ declare variable $config:annotations := map {
     "term": function($properties as map(*), $content as function(*)) {
         <term xmlns="http://www.tei-c.org/ns/1.0" ref="{$properties?ref}">{$content()}</term>
     },
-    "organisation": function($properties as map(*), $content as function(*)) {
+    "organization": function($properties as map(*), $content as function(*)) {
         <orgName xmlns="http://www.tei-c.org/ns/1.0" ref="{$properties?ref}">{$content()}</orgName>
     },
     "note": function($properties as map(*), $content as function(*)) {

--- a/templates/pages/annotate.html
+++ b/templates/pages/annotate.html
@@ -37,7 +37,7 @@
                             <div class="toolbar">
                                 <!--paper-icon-button id="clear-all" icon="icons:refresh"></paper-icon-button-->
                                 <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.person" title="Person" data-type="person" data-shortcut="⌘+⇧+p,ctrl+⇧+p" icon="social:person" disabled="disabled"></paper-icon-button>
-                                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.organisation" title="Organisation" data-type="organisation" data-shortcut="⌘+⇧+o,ctrl+⇧+o" icon="social:people" disabled="disabled"></paper-icon-button>
+                                <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.organization" title="organization" data-type="organization" data-shortcut="⌘+⇧+o,ctrl+⇧+o" icon="social:people" disabled="disabled"></paper-icon-button>
                                 <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.place" title="Place" data-type="place" icon="maps:place" data-shortcut="⌘+⇧+q,ctrl+⇧+q" disabled="disabled"></paper-icon-button>
                                 <paper-icon-button class="annotation-action authority" data-i18n="[title]annotations.term" title="Term" data-type="term" icon="icons:bookmark" data-shortcut="⌘+⇧+t,ctrl+⇧+t" disabled="disabled"></paper-icon-button>
                                 <paper-icon-button class="annotation-action" data-i18n="[title]annotations.date" title="Date" data-type="date" icon="icons:today" data-shortcut="⌘+⇧+d,ctrl+⇧+d" disabled="disabled"></paper-icon-button>
@@ -51,7 +51,7 @@
                             </div>
                             <iron-form id="edit-form">
                                 <form action="">
-                                    <div class="annotation-form person organisation place term">
+                                    <div class="annotation-form person organization place term">
                                         <paper-input id="form-ref" name="ref" data-i18n="[label]annotations.reference" label="Reference">
                                             <paper-icon-button slot="prefix" icon="search" data-i18n="[label]annotations.lookup"></paper-icon-button>
                                         </paper-input>
@@ -128,7 +128,7 @@
             <paper-dialog id="authority-dialog">
                 <paper-dialog-scrollable>
                     <pb-authority-lookup subscribe="transcription" emit="transcription">
-                        <pb-authority connector="Custom" name="organisation">
+                        <pb-authority connector="Custom" name="organization">
                             <pb-authority connector="GND" prefix="gnd"></pb-authority>
                         </pb-authority>
                         <!--pb-authority connector="GeoNames" name="place" user="existdb" prefix="geo"></pb-authority-->

--- a/transform/annotations-epub.invalid.xql
+++ b/transform/annotations-epub.invalid.xql
@@ -543,7 +543,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         html:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)
                     case element(orgName) return
-                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)
+                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)
                     case element(place) return
                         (
                             html:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3),

--- a/transform/annotations-epub.xql
+++ b/transform/annotations-epub.xql
@@ -575,7 +575,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         html:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)
                     case element(orgName) return
-                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)
+                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)
                     case element(place) return
                         (
                             html:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3),

--- a/transform/annotations-latex.invalid.xql
+++ b/transform/annotations-latex.invalid.xql
@@ -555,7 +555,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         latex:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)
                     case element(orgName) return
-                        latex:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)
+                        latex:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)
                     case element(place) return
                         (
                             latex:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3),

--- a/transform/annotations-latex.xql
+++ b/transform/annotations-latex.xql
@@ -560,7 +560,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         latex:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)
                     case element(orgName) return
-                        latex:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)
+                        latex:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)
                     case element(place) return
                         (
                             latex:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3),

--- a/transform/annotations-print.invalid.xql
+++ b/transform/annotations-print.invalid.xql
@@ -527,7 +527,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         fo:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)
                     case element(orgName) return
-                        fo:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)
+                        fo:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)
                     case element(place) return
                         (
                             fo:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3),

--- a/transform/annotations-print.xql
+++ b/transform/annotations-print.xql
@@ -532,7 +532,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         fo:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)
                     case element(orgName) return
-                        fo:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)
+                        fo:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)
                     case element(place) return
                         (
                             fo:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3),

--- a/transform/annotations-web.invalid.xql
+++ b/transform/annotations-web.invalid.xql
@@ -541,7 +541,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         html:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)                        => model:map($node, $trackIds)
                     case element(orgName) return
-                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)                        => model:map($node, $trackIds)
+                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)                        => model:map($node, $trackIds)
                     case element(place) return
                         (
                             html:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3)                            => model:map($node, $trackIds),

--- a/transform/annotations-web.xql
+++ b/transform/annotations-web.xql
@@ -573,7 +573,7 @@ declare function model:apply($config as map(*), $input as node()*) {
                     case element(term) return
                         html:inline($config, ., ("tei-term", "annotation", "annotation-term", "term", css:map-rend-to-class(.)), .)                        => model:map($node, $trackIds)
                     case element(orgName) return
-                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organisation", "organisation", css:map-rend-to-class(.)), .)                        => model:map($node, $trackIds)
+                        html:inline($config, ., ("tei-orgName", "annotation", "annotation-organization", "organization", css:map-rend-to-class(.)), .)                        => model:map($node, $trackIds)
                     case element(place) return
                         (
                             html:heading($config, ., ("tei-place1", css:map-rend-to-class(.)), placeName[@type="full"], 3)                            => model:map($node, $trackIds),

--- a/transform/annotations.css
+++ b/transform/annotations.css
@@ -8,7 +8,7 @@
     font-style: italic;
 }
 
-.organisation {
+.organization {
     font-style: italic;
 }
 


### PR DESCRIPTION
Adopting the variant used [on tei-c.org](https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-orgName.html). 

A corresponding PR to the components repo is forthcoming.

As discussed in Slack.