### PR TITLE
fixes webtest: /api/document/{id}/content and /api/parts/{id}/json

### DIFF
--- a/modules/lib/api/caching.xql
+++ b/modules/lib/api/caching.xql
@@ -31,7 +31,9 @@ declare function cutil:check-last-modified($request as map(*), $nodes as node()*
         else
             ()
     return (
-        response:set-header("Last-Modified", cutil:format-http-date(head($lastModified))),
+        if(string-length($lastModified) >0) 
+        then (response:set-header("Last-Modified", cutil:format-http-date(head($lastModified)))) 
+        else (),        
         if ($shouldReturn304) then
             router:response(304, "", "")
         else

--- a/modules/lib/api/document.xql
+++ b/modules/lib/api/document.xql
@@ -342,7 +342,12 @@ declare function dapi:get-fragment($request as map(*)) {
     let $path := xmldb:decode-uri($request?parameters?doc)
     let $docs := config:get-document($path)
     return
-        cutil:check-last-modified($request, $docs, dapi:get-fragment(?, ?, $path))
+        if($docs) 
+        then (
+            cutil:check-last-modified($request, $docs, dapi:get-fragment(?, ?, $path))
+        ) else (
+            router:response(404, "document not found", $path)    
+        )
 };
 
 declare function dapi:get-fragment($request as map(*), $docs as node()*, $path as xs:string) {
@@ -499,19 +504,24 @@ declare %private function dapi:extract-footnotes($html as element()*) {
     }
 };
 
-declare function dapi:table-of-contents($request as map(*)) {
+declare function dapi:table-of-contents($request as map(*)) {    
     let $doc := xmldb:decode-uri($request?parameters?id)
     let $documents := config:get-document($doc)
     return
-        cutil:check-last-modified($request, $documents, function($request as map(*), $documents as node()*) {
-    let $view := head(($request?parameters?view, $config:default-view))
-            let $xml := pages:load-xml($documents, $view, (), $doc)
-    return
-        if (exists($xml)) then
-            pages:toc-div(root($xml?data), $xml, $request?parameters?target, $request?parameters?icons)
-        else
-            error($errors:NOT_FOUND, "Document " || $doc || " not found")
-        })
+        if($documents)
+        then (
+            cutil:check-last-modified($request, $documents, function($request as map(*), $documents as node()*) {
+                let $view := head(($request?parameters?view, $config:default-view))
+                let $xml := pages:load-xml($documents, $view, (), $doc)
+                return
+                if (exists($xml)) then
+                    pages:toc-div(root($xml?data), $xml, $request?parameters?target, $request?parameters?icons)
+                else
+                    error($errors:NOT_FOUND, "Document " || $doc || " not found")
+                })
+        ) else (
+            router:response(404, "document not found", $doc)        
+        )
 };
 
 declare function dapi:preview($request as map(*)) {


### PR DESCRIPTION
Note: https://github.com/windauer/tei-publisher-app/runs/6239988188?check_suite_focus=true#step:6:172 is still failing but I assume the CI takes the eedtiones/tei-publisher-app instead of windauer/tei-publisher-app here. On my local machine the 2 failing tests are green now. 