### PR TITLE
Require eXist 5.3.0

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <package xmlns="http://expath.org/ns/pkg" name="http://existsolutions.com/apps/tei-publisher" abbrev="tei-publisher" version="7.1.0" spec="1.0">
     <title>TEI Publisher</title>
-    <dependency processor="http://exist-db.org" semver-min="5.2.0" />
+    <dependency processor="http://exist-db.org" semver-min="5.3.0" />
     <dependency package="http://exist-db.org/html-templating" semver-min="1.0.2"/>
     <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver-min="2.10.0" />
     <dependency package="http://exist-db.org/open-api/router" semver-min="0.5.1" semver-max="0"/>

--- a/modules/lib/api/generate.xql
+++ b/modules/lib/api/generate.xql
@@ -29,7 +29,7 @@ import module namespace errors = "http://exist-db.org/xquery/router/errors";
 declare variable $deploy:EXPATH_DESCRIPTOR :=
     <package xmlns="http://expath.org/ns/pkg"
         version="0.1" spec="1.0">
-        <dependency processor="http://exist-db.org" semver-min="5.2.0"/>
+        <dependency processor="http://exist-db.org" semver-min="5.3.0"/>
         <dependency package="http://exist-db.org/html-templating"/>
         <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver-min="2.10.0"/>
         <dependency package="http://exist-db.org/open-api/router" semver-min="0.5.1"/>


### PR DESCRIPTION
Closes #98. 

Note that the following links indicate that for Docker purposes we are recommending 5.3.1:

- https://github.com/eeditiones/tei-publisher-app/blob/master/Dockerfile#L69
- https://github.com/eeditiones/teipublisher-docker-compose/blob/master/Dockerfile.tmpl#L51

I'd be happy to adjust this PR to require eXist 5.3.1 if that's better for consistency. 

Also, the README could probably be added to this PR. It currently states:

> TEI Publisher from version 5.0.0 requires [eXist-db 5.0.0](https://bintray.com/existdb/releases/exist/5.0.0/view/files) or later.

I think the more accurate statement is that from version 7.1.0 TEI Publisher requires eXist 5.2.0 - see https://github.com/eeditiones/tei-publisher-app/commit/a6c3708de5b71ddd09ac4b342010a7c44c366517. (We'd just need to update this statement again when TEI Publisher 8 is released... updating in this PR would be premature.)

(Also, that link to bintray should be updated to eXist's GitHub Releases page.)

Also, the README references "existdb/teipublisher:6.0.0" when discussing the Docker images - whereas [the current release to DockerHub](https://hub.docker.com/r/existdb/teipublisher/tags) is 7.1.0 (or 7.1.0-patched?). 

And the README's statement that the Docker image "installs 5.2.0" should be updated to say "5.3.1." So README could be updated here. I'd happily do so in this PR if anyone would tell me what exactly to replace ":6.0.0" with - should it be ":7.1.0" or ":7.1.0-patched"? Or would ":latest" be better? I honestly don't know.