### PR TITLE
[fix] some readers may not load styles in note popup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@teipublisher/pb-components": "latest"
       },
       "devDependencies": {
+        "adm-zip": "^0.5.9",
         "axios": "^0.21.1",
         "chai": "^4.2.0",
         "chai-openapi-response-validator": "^0.9.4",
@@ -830,6 +831,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/ajv": {
@@ -4592,6 +4602,12 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true
+    },
+    "adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
       "dev": true
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@teipublisher/pb-components": "latest"
   },
   "devDependencies": {
+    "adm-zip": "^0.5.9",
     "axios": "^0.21.1",
     "chai": "^4.2.0",
     "chai-openapi-response-validator": "^0.9.4",

--- a/test/note-popup.test.js
+++ b/test/note-popup.test.js
@@ -1,0 +1,82 @@
+const util = require('./util.js');
+const path = require('path');
+const FormData = require('form-data');
+const chai = require('chai');
+const chaiXML = require('chai-xml');
+const expect = chai.expect;
+const chaiResponseValidator = require('chai-openapi-response-validator');
+const jsdom = require("jsdom");
+const zip = require('adm-zip');
+const { JSDOM } = jsdom;
+
+const spec = path.resolve("./modules/lib/api.json");
+chai.use(chaiResponseValidator(spec));
+chai.use(chaiXML);
+
+const testXml = `<TEI xmlns="http://www.tei-c.org/ns/1.0">
+<teiHeader>
+  <fileDesc>
+    <titleStmt>
+      <title>EPUB note popup styles</title>
+    </titleStmt>
+    <publicationStmt>
+      <p/>
+    </publicationStmt>
+    <sourceDesc>
+      <p/>
+    </sourceDesc>
+  </fileDesc>
+</teiHeader>
+<text>
+  <body>
+    <div type="document" n="1" xml:id="d1" subtype="document">
+      <head>Document 1</head>
+      <note n="1" xml:id="d1fn1" type="source"><hi rend="italic">italic note</hi></note>
+      <note n="2" xml:id="d1fn2" type="source"><hi rend="bold">bold note</hi></note>
+      <note n="3" xml:id="d1fn3" type="source"><hi rend="underline">underlined note</hi></note>
+    </div>
+    <div type="document" n="2" xml:id="d2" subtype="document">
+      <head>Document 2</head>
+      <p><hi rend="italic">italic note</hi></p>
+      <p><hi rend="bold">bold note</hi></p>
+      <p><hi rend="underline">underlined note</hi></p>
+    </div>
+  </body>
+</text>
+</TEI>`;
+
+function getPages(data) {
+  return new zip(Buffer.from(data)).getEntries()
+    .filter(({ entryName }) => entryName.startsWith('OEBPS/N'))
+    .map(entry => entry?.getData().toString('utf-8'));
+}
+
+describe('Text style in footnotes popup', function() {
+    before(async () => {
+      await util.login();
+      const formData = new FormData()
+      formData.append('files[]', testXml, "note-popup.xml");
+      const res = await util.axios.post('upload/playground', formData, {
+          headers: formData.getHeaders()
+      });
+      expect(res.data).to.have.length(1);
+      expect(res.data[0].name).to.equal('/db/apps/tei-publisher/data/playground/note-popup.xml');
+      expect(res).to.satisfyApiSpec;
+    });
+
+    it('em, strong, and u elements should be used to style texts in notes', async () => {
+      const res = await util.axios.get('document/playground%2Fnote-popup.xml/epub', { responseType: 'arraybuffer' });
+      expect(res.status).to.equal(200);
+      const pages = getPages(res.data);
+      const document1 = new JSDOM(pages[0], { contentType: "application/xml" }).window.document;
+      expect(document1.querySelector('aside em').textContent.trim()).to.equal('italic note');
+      expect(document1.querySelector('aside strong').textContent.trim()).to.equal('bold note');
+      expect(document1.querySelector('aside u').textContent.trim()).to.equal('underlined note');
+      const document2 = new JSDOM(pages[1], { contentType: "application/xml" }).window.document;
+      expect(document2.querySelector('p em')).to.be.null;
+      expect(document2.querySelector('p strong')).to.be.null;
+      expect(document2.querySelector('p u')).to.be.null;
+    });
+
+    after(util.logout);
+});

--- a/transform/teipublisher-epub.xql
+++ b/transform/teipublisher-epub.xql
@@ -64,7 +64,7 @@ declare function model:apply($config as map(*), $input as node()*) {
     $input !         (
             let $node := 
                 .
-            return
+            let $output := 
                             typeswitch(.)
                     case element(castItem) return
                         (: Insert item, rendered as described in parent list rendition. :)
@@ -553,8 +553,16 @@ declare function model:apply($config as map(*), $input as node()*) {
                     default return 
                         $config?apply($config, ./node())
 
+            return
+                if (./ancestor-or-self::note) then
+                    let $rend := concat(./@rend, ' ')
+                    let $styled := $output
+                    let $styled := if (contains($rend, 'italic ')) then <em>{$styled}</em> else $styled
+                    let $styled := if (contains($rend, 'bold ')) then <strong>{$styled}</strong> else $styled
+                    let $styled := if (contains($rend, 'underline ')) then <u>{$styled}</u> else $styled
+                    return $styled
+                else $output
         )
-
 };
 
 declare function model:apply-children($config as map(*), $node as element(), $content as item()*) {


### PR DESCRIPTION
render `.italic`, `.underline`, `.bold` with `<em>`, `<u>`, `<strong>` to fix this issue

This open source contribution to the tei-publisher-app project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.