### PR TITLE
Always use the most recent code in tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,6 @@ FROM builder as tei
 ARG TEMPLATING_VERSION=1.0.4
 ARG PUBLISHER_LIB_VERSION=2.10.0
 ARG ROUTER_VERSION=0.5.1
-ARG PUBLISHER_VERSION=master
 ARG SHARED_RESOURCES_VERSION=0.9.1
 ARG SHAKESPEARE_VERSION=1.1.2
 ARG VANGOGH_VERSION=1.0.6
@@ -53,10 +52,8 @@ RUN  git clone https://github.com/eeditiones/vangogh.git \
     && ant
 
 # Build tei-publisher-app
-RUN  git clone https://github.com/eeditiones/tei-publisher-app.git \
-    && cd tei-publisher-app \
-    && echo Checking out ${PUBLISHER_VERSION} \
-    && git checkout ${PUBLISHER_VERSION} \
+COPY . tei-publisher-app/
+RUN  cd tei-publisher-app \
     && ant
 
 RUN curl -L -o /tmp/oas-router-${ROUTER_VERSION}.xar http://exist-db.org/exist/apps/public-repo/public/oas-router-${ROUTER_VERSION}.xar


### PR DESCRIPTION
Use the checked out code in the same repo/branch/commit/PR in the docker image to test against.
fixes #112

This open source contribution to the tei-publisher-app project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov.