### PR TITLE
fix(expath-pkg): oas-router w/o semver-max range

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -4,5 +4,5 @@
     <dependency processor="http://exist-db.org" semver-min="5.3.0" />
     <dependency package="http://exist-db.org/html-templating" semver-min="1.0.4"/>
     <dependency package="http://existsolutions.com/apps/tei-publisher-lib" semver-min="2.10.0" />
-    <dependency package="http://exist-db.org/open-api/router" semver-min="0.5.1" semver-max="0"/>
+    <dependency package="http://exist-db.org/open-api/router" semver-min="0.5.1"/>
 </package>


### PR DESCRIPTION
fixes #121

TEI-publisher can be installed on a fresh eXist-db again.