### PR TITLE
[fix] notes in document title should not appear in navigation entry

### DIFF
--- a/modules/lib/epub.xql
+++ b/modules/lib/epub.xql
@@ -274,7 +274,7 @@ declare function epub:toc-nav-div($config, $root as element()) {
         let $headings := nav:get-section-heading($config?docConfig, $div)
         let $html :=
             if ($headings) then
-                normalize-space(string-join($headings//text()))
+                normalize-space(string-join($headings//text()[not(./ancestor::tei:note)]))
             else
                 "[no title]"
         let $file := epub:generate-id(nav:get-section-for-node($config?docConfig, $div))

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@teipublisher/pb-components": "*"
       },
       "devDependencies": {
+        "adm-zip": "^0.5.9",
         "axios": "^0.21.2",
         "chai": "^4.2.0",
         "chai-openapi-response-validator": "^0.9.4",
@@ -830,6 +831,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/ajv": {
@@ -4557,6 +4567,12 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
       "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+      "dev": true
+    },
+    "adm-zip": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.9.tgz",
+      "integrity": "sha512-s+3fXLkeeLjZ2kLjCBwQufpI5fuN+kIGBxu6530nVQZGVol0d7Y/M88/xw9HGGUcJjKf8LutN3VPRUBq6N7Ajg==",
       "dev": true
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@teipublisher/pb-components": "latest"
   },
   "devDependencies": {
+    "adm-zip": "^0.5.9",
     "axios": "^0.21.2",
     "chai": "^4.2.0",
     "chai-openapi-response-validator": "^0.9.4",

--- a/test/title-notes.test.js
+++ b/test/title-notes.test.js
@@ -1,0 +1,65 @@
+const util = require('./util.js');
+const path = require('path');
+const FormData = require('form-data');
+const chai = require('chai');
+const chaiXML = require('chai-xml');
+const expect = chai.expect;
+const chaiResponseValidator = require('chai-openapi-response-validator');
+const jsdom = require("jsdom");
+const zip = require('adm-zip');
+const { JSDOM } = jsdom;
+
+const spec = path.resolve("./modules/lib/api.json");
+chai.use(chaiResponseValidator(spec));
+chai.use(chaiXML);
+
+const testXml = `<TEI xmlns="http://www.tei-c.org/ns/1.0">
+<teiHeader>
+  <fileDesc>
+    <titleStmt>
+      <title>EPUB title notes Test</title>
+    </titleStmt>
+    <publicationStmt>
+      <p />
+    </publicationStmt>
+    <sourceDesc>
+      <p />
+    </sourceDesc>
+  </fileDesc>
+</teiHeader>
+<text>
+  <body>
+    <div type="document" n="1" xml:id="d1" subtype="document">
+      <head>Document 1<note n="1" xml:id="d1fn1" type="source">note</note></head>
+      <p>Document 1 body</p>
+    </div>
+  </body>
+</text>
+</TEI>`;
+
+function getNav(data) {
+  return new zip(Buffer.from(data)).getEntries().find(({ entryName }) => entryName === 'OEBPS/nav.xhtml')?.getData().toString('utf-8');
+}
+
+describe('Notes in document title', function() {
+    before(async () => {
+      await util.login();
+      const formData = new FormData()
+      formData.append('files[]', testXml, "title-note.xml");
+      const res = await util.axios.post('upload/playground', formData, {
+          headers: formData.getHeaders()
+      });
+      expect(res.data).to.have.length(1);
+      expect(res.data[0].name).to.equal('/db/apps/tei-publisher/data/playground/title-note.xml');
+      expect(res).to.satisfyApiSpec;
+    });
+
+    it('notes in document title should not appear in navigation entry', async () => {
+      const res = await util.axios.get('document/playground%2Ftitle-note.xml/epub', { responseType: 'arraybuffer' });
+      expect(res.status).to.equal(200);
+      const document = new JSDOM(getNav(res.data), { contentType: "application/xml" }).window.document;
+      expect(document.querySelector('a[href$="#d1"]').textContent).to.equal('Document 1');
+    });
+
+    after(util.logout);
+});


### PR DESCRIPTION
Fix for an issue where there is a `note` in the `head` element, the text of the note will appear in the navigation entry.

this PR replaces #106 

This open source contribution to the tei-publisher-app project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov.