### PR TITLE
dynamic switching of context-path

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -303,10 +303,13 @@ return
 declare variable $config:context-path :=
     let $prop := util:system-property("teipublisher.context-path")
     return
-        if (empty($prop) or $prop = "auto") then
-            request:get-context-path() || substring-after($config:app-root, "/db")
-        else
-            $prop
+        if (not(empty($prop)) and $prop != "auto") 
+            then ($prop)
+        else if(not(empty(request:get-header("X-Forwarded-Host"))))
+            then ("")
+        else ( 
+            request:get-context-path() || substring-after($config:app-root, "/db") 
+        )  
 ;
 
 (:~


### PR DESCRIPTION
recreated PR for dynamic switching of context-path. 

Comment from @wolfgangmm:  "Requires documentation! We should also make sure that X-Forward-Host is correctly set. In my testing with our docker nginx config, this was not the case, probably due to my lack of nginx knowledge." 