### PR TITLE
Tp8 docker maintenance

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/java:17-bullseye
+FROM mcr.microsoft.com/devcontainers/java:8-bullseye
 
 ARG EXIST_VERSION=6.2.0
 ARG TEMPLATING_VERSION=1.1.0
@@ -80,8 +80,7 @@ ENV JAVA_OPTS \
     -Djetty.ssl.port=${HTTPS_PORT} \
     -Dfile.encoding=UTF8 \
     -Dsun.jnu.encoding=UTF-8 \
-    -XX:+UseNUMA \
-    -XX:+UseZGC \
+    -XX:+UseG1GC \
     -XX:+UseStringDeduplication \
     -XX:+UseContainerSupport \
     -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \ 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"    

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,6 +19,7 @@ on:
 env:
   # TODO: Change variable to your image's name.
   IMAGE_NAME: teipublisher
+  VERSION: $(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
 jobs:
   # Run tests.
@@ -61,11 +62,31 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --build-arg PUBLISHER_VERSION=master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: linux/amd64,linux/arm64 
 
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+      - name: Make buildkit default
+        uses: docker/setup-buildx-action@v2
+        id: buildx
+        with:
+          install: true
+
+      # was ${{ github.actor }}
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # - name: Build image
+      #   run: docker build . --file Dockerfile --tag $IMAGE_NAME --build-arg PUBLISHER_VERSION=master
+
+      # - name: Log into registry
+      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         run: |
@@ -86,5 +107,21 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          # docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          # docker push $IMAGE_ID:$VERSION 
+
+      - name: Push image
+        if: github.ref == 'refs/heads/master'
+        uses: docker/build-push-action@v4
+        with:
+          context: ./
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            PUBLISHER_VERSION=master
+          builder: ${{ steps.buildx.outputs.name }}
+          push: true
+          tags: |
+            ghcr.io /${{ github.repository }}/${{ IMAGE_NAME }}:master
+            ghcr.io /${{ github.repository }}/${{ IMAGE_NAME }}:${{ VERSION }
+          # cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/existdb:buildcache
+          # cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/existdb:buildcache,mode=max      

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -19,7 +19,6 @@ on:
 env:
   # TODO: Change variable to your image's name.
   IMAGE_NAME: teipublisher
-  VERSION: $(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
 jobs:
   # Run tests.
@@ -73,6 +72,17 @@ jobs:
         with:
           install: true
 
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/eeditiones/tei-publisher-app/teipublisher
+          # TODO(DP): This could be extended further
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}    
+
+
       # was ${{ github.actor }}
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
@@ -82,46 +92,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Build image
-      #   run: docker build . --file Dockerfile --tag $IMAGE_NAME --build-arg PUBLISHER_VERSION=master
-
-      # - name: Log into registry
-      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-      - name: Push image
-        run: |
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
-          
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=master
-
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          # docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          # docker push $IMAGE_ID:$VERSION 
-
       - name: Push image
         if: github.ref == 'refs/heads/master'
         uses: docker/build-push-action@v4
         with:
-          context: ./
+          context: .
           platforms: linux/amd64,linux/arm64
           build-args: |
             PUBLISHER_VERSION=master
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: |
-            ghcr.io /${{ github.repository }}/${{ IMAGE_NAME }}:master
-            ghcr.io /${{ github.repository }}/${{ IMAGE_NAME }}:${{ VERSION }
-          # cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/existdb:buildcache
-          # cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/existdb:buildcache,mode=max      
+          tags: ${{ steps.meta.outputs.tags }} 
+          labels: ${{ steps.meta.outputs.labels }}   

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ RUN curl -L -o apache-ant-${ANT_VERSION}-bin.tar.gz http://www.apache.org/dist/a
 
 ENV PATH ${PATH}:${ANT_HOME}/bin
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - \
-    && apt-get install -y nodejs \
-    && curl -L https://www.npmjs.com/install.sh | sh
+# RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - \
+#     && apt-get install -y nodejs \
+#     && curl -L https://www.npmjs.com/install.sh | sh
 
 FROM builder as tei
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8-jdk-slim as builder
 
 USER root
 
-ENV ANT_VERSION 1.10.12
+ENV ANT_VERSION 1.10.13
 ENV ANT_HOME /etc/ant-${ANT_VERSION}
 
 WORKDIR /tmp
@@ -23,18 +23,18 @@ RUN curl -L -o apache-ant-${ANT_VERSION}-bin.tar.gz http://www.apache.org/dist/a
 
 ENV PATH ${PATH}:${ANT_HOME}/bin
 
-# RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-#     && apt-get install -y nodejs \
-#     && curl -L https://www.npmjs.com/install.sh | sh
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -L https://www.npmjs.com/install.sh | sh
 
 FROM builder as tei
 
-ARG TEMPLATING_VERSION=1.0.4
-ARG PUBLISHER_LIB_VERSION=master
-ARG ROUTER_VERSION=1.7.3
-ARG SHARED_RESOURCES_VERSION=0.9.1
-ARG SHAKESPEARE_VERSION=1.1.2
-ARG VANGOGH_VERSION=1.0.6
+# TODO(DP): Demo App Versions need updating
+ARG TEMPLATING_VERSION=1.1.0
+ARG PUBLISHER_LIB_VERSION=3.0.0
+ARG ROUTER_VERSION=1.8.0
+ARG SHAKESPEARE_VERSION=migrate-to-tp8
+ARG VANGOGH_VERSION=migrate-to-TP8
 
 # add key
 RUN  mkdir -p ~/.ssh && ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
@@ -68,18 +68,8 @@ RUN  cd tei-publisher-app \
 
 RUN curl -L -o /tmp/roaster-${ROUTER_VERSION}.xar http://exist-db.org/exist/apps/public-repo/public/roaster-${ROUTER_VERSION}.xar
 RUN curl -L -o /tmp/templating-${TEMPLATING_VERSION}.xar http://exist-db.org/exist/apps/public-repo/public/templating-${TEMPLATING_VERSION}.xar
-RUN curl -L -o /tmp/shared-resources-${SHARED_RESOURCES_VERSION}.xar http://exist-db.org/exist/apps/public-repo/public/shared-resources-${SHARED_RESOURCES_VERSION}.xar
 
-FROM eclipse-temurin:11-jre-alpine
-
-ARG EXIST_VERSION=6.0.1
-
-RUN apk add curl
-
-RUN curl -L -o /tmp/exist-distribution-${EXIST_VERSION}-unix.tar.bz2 https://github.com/eXist-db/exist/releases/download/eXist-${EXIST_VERSION}/exist-distribution-${EXIST_VERSION}-unix.tar.bz2 \
-    && tar xfj /tmp/exist-distribution-${EXIST_VERSION}-unix.tar.bz2 -C /tmp \
-    && rm /tmp/exist-distribution-${EXIST_VERSION}-unix.tar.bz2 \
-    && mv /tmp/exist-distribution-${EXIST_VERSION} /exist
+FROM duncdrum/existdb:6.2.0-j8
 
 COPY --from=tei /tmp/tei-publisher-app/build/*.xar /exist/autodeploy/
 COPY --from=tei /tmp/shakespeare/build/*.xar /exist/autodeploy/
@@ -88,7 +78,7 @@ COPY --from=tei /tmp/*.xar /exist/autodeploy/
 
 WORKDIR /exist
 
-ARG ADMIN_PASS=none
+# ARG ADMIN_PASS=none
 
 ARG HTTP_PORT=8080
 ARG HTTPS_PORT=8443
@@ -97,22 +87,27 @@ ENV NER_ENDPOINT=http://localhost:8001
 ENV CONTEXT_PATH=auto
 ENV PROXY_CACHING=false
 
-ENV JAVA_OPTS \
-    -Djetty.port=${HTTP_PORT} \
-    -Djetty.ssl.port=${HTTPS_PORT} \
-    -Dfile.encoding=UTF8 \
-    -Dsun.jnu.encoding=UTF-8 \
-    -XX:+UseG1GC \
-    -XX:+UseStringDeduplication \
-    -XX:+UseContainerSupport \
-    -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \ 
-    -XX:+ExitOnOutOfMemoryError
+ENV JAVA_TOOL_OPTIONS \
+  -Dfile.encoding=UTF8 \
+  -Dsun.jnu.encoding=UTF-8 \
+  -Djava.awt.headless=true \
+  -Dorg.exist.db-connection.cacheSize=${CACHE_MEM:-256}M \
+  -Dorg.exist.db-connection.pool.max=${MAX_BROKER:-20} \
+  -Dlog4j.configurationFile=/exist/etc/log4j2.xml \
+  -Dexist.home=/exist \
+  -Dexist.configurationFile=/exist/etc/conf.xml \
+  -Djetty.home=/exist \
+  -Dexist.jetty.config=/exist/etc/jetty/standard.enabled-jetty-configs \
+  -Dteipublisher.ner-endpoint=${NER_ENDPOINT} \
+  -Dteipublisher.context-path=${CONTEXT_PATH} \
+  -Dteipublisher.proxy-caching=${PROXY_CACHING} \
+  -XX:+UseG1GC \
+  -XX:+UseStringDeduplication \
+  -XX:+UseContainerSupport \
+  -XX:MaxRAMPercentage=${JVM_MAX_RAM_PERCENTAGE:-75.0} \
+  -XX:+ExitOnOutOfMemoryError
 
-# pre-populate the database by launching it once
-RUN bin/client.sh -l --no-gui --xpath "system:get-version()"
-
-RUN if [ "${ADMIN_PASS}" != "none" ]; then bin/client.sh -l --no-gui --xpath "sm:passwd('admin', '${ADMIN_PASS}')"; fi
+# pre-populate the database by launching it once and change default pw
+RUN [ "java", "org.exist.start.Main", "client", "--no-gui",  "-l", "-u", "admin", "-P", "", "-x", "sm:passwd('admin','none')" ]
 
 EXPOSE ${HTTP_PORT}
-
-ENTRYPOINT JAVA_OPTS="${JAVA_OPTS} -Dteipublisher.ner-endpoint=${NER_ENDPOINT} -Dteipublisher.context-path=${CONTEXT_PATH} -Dteipublisher.proxy-caching=${PROXY_CACHING}" /exist/bin/startup.sh

--- a/test/generate.test.js
+++ b/test/generate.test.js
@@ -92,7 +92,8 @@ describe('/api/generate [authenticated]', function () {
         `;
         const res = await axios.get(`http://localhost:8080/exist/rest/db?_query=${encodeURIComponent(query)}&_wrap=no`, {
             auth: {
-                "username": "admin"
+                "username": "admin",
+                "password": "none"
             }
         });
         expect(res.status).to.equal(200);


### PR DESCRIPTION
Version updates to various dependencies in devcontainer and dockerfile.

Switch to `duncdrum/existdb` base image in Dockerfile, currently install DEMO apps from open PRs for compatibility
see https://github.com/eeditiones/shakespeare/pull/8
see https://github.com/eeditiones/vangogh/pull/2

Use J8 instead of J17 for exist 6.2.0

streamlined and updated GitHub action scripts

for a dry run see https://github.com/eeditiones/tei-publisher-ner/pull/4

close https://github.com/eeditiones/tei-publisher-planning/issues/36

Going to take a look at the Docker-compose now
see https://github.com/eeditiones/teipublisher-docker-compose/issues/5
see https://github.com/eeditiones/teipublisher-docker-compose/issues/4

Please test both devcontainers and dockerfiles for your workflows.

Changes:
no more shell (could switch to debug images for that)
automatic updates of stock expaths app inside existdb on top of os and java updates
switched from alpine to Debian for greater consistency
`ADMIN_PASS` clear text variable no longer in use
multi-arch builds for arm and intel
