### PR TITLE
deleted 'browse:list-works' in documents.html 

### DIFF
--- a/templates/basic/templates/documents.html
+++ b/templates/basic/templates/documents.html
@@ -1,6 +1,6 @@
 <div data-template="browse:is-writeable" class="collection">
     <div data-template="browse:dispatch-action"/>
-    <div data-template="browse:list-works">
+    <div>
         <paper-button class="parent-link" data-template="browse:parent-collection">
             <iron-icon icon="icons:folder"></iron-icon>
             <pb-i18n key="browse.up">Up</pb-i18n>


### PR DESCRIPTION
removed browse:list-works in documents.html as it got removed in browse.xql and is not required anymore