### PR TITLE
Fix facets display and handle full url facs

### DIFF
--- a/data/test/F-rom.xml
+++ b/data/test/F-rom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?teipublisher template="facsimile.html" odd="shakespeare.odd" view="page" media="pdf epub print"?>
+<?teipublisher template="shakespeare.html" odd="shakespeare.odd" view="page" media="pdf epub print"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0">
     <teiHeader>
         <fileDesc>

--- a/odd/teipublisher.odd
+++ b/odd/teipublisher.odd
@@ -392,6 +392,20 @@
                       </model>
                   </elementSpec>
                   <elementSpec ident="pb" mode="change">
+                    <model predicate="@facs" behaviour="webcomponent">
+                        <desc>Use the url from the facs attribute to link with IIIF image</desc>
+                        <param name="name" value="'pb-facs-link'"/>
+                        <param name="facs" value="@facs"/>
+                        <param name="label" value="@n"/>
+                        <param name="emit" value="'transcription'"/>
+                    </model>
+                    <model predicate="starts-with(@facs, 'iiif:')" behaviour="webcomponent">
+                        <desc>If facs attribute starts with iiif prefix, use the trailing part as a link to the IIIF image</desc>
+                        <param name="name" value="'pb-facs-link'"/>
+                        <param name="facs" value="replace(@facs, '^iiif:(.*)$', '$1')"/>
+                        <param name="label" value="'Page'"/>
+                        <param name="emit" value="'transcription'"/>
+                    </model>
                     <model behaviour="break" useSourceRendition="true">
                       <param name="type" value="'page'"/>
                       <param name="label" value="(concat(if(@n) then concat(@n,' ') else '',if(@facs) then                   concat('@',@facs) else ''))"/>
@@ -399,7 +413,7 @@
                       <outputRendition scope="before">content: '[Page ';</outputRendition>
                       <outputRendition scope="after">content: ']';</outputRendition>
                     </model>
-                  </elementSpec>
+                </elementSpec>
                   <elementSpec ident="postscript" mode="change">
                     <model behaviour="block"/>
                   </elementSpec>

--- a/templates/pages/shakespeare.html
+++ b/templates/pages/shakespeare.html
@@ -11,7 +11,7 @@
     <link rel="shortcut icon" type="image/png" href="resources/images/favicon-64.png" sizes="64x64" />
 
     <title data-template="config:app-title"></title>
-    <meta name="description" content="Basic side-by-side facsimile and transcription" />
+    <meta name="description" content="Shakespeare Play" />
     <link rel="stylesheet" href="resources/css/theme.css" />
     <script type="module" src="pb-components-bundle.js" data-template="pages:load-components"></script>
     <style>
@@ -72,7 +72,7 @@
                 <main class="content-body">
                     <pb-view id="view1" src="document1" column-separator=".tei-cb" append-footnotes="append-footnotes"
                         subscribe="transcription" emit="transcription" wait-for="#facsimile" />
-                    <pb-facsimile id="facsimile"
+                    <pb-facsimile id="facsimile" base-uri="https://apps.existsolutions.com/cantaloupe/iiif/2/"
                         default-zoom-level="0" show-navigation-control="show-navigation-control"
                         show-navigator="show-navigator"
                         subscribe="transcription" />


### PR DESCRIPTION
* fix facets display for hierarchical facets (nested, multi-value)
* add models for `pb` which produce `pb-facs-link` elements based on the value of `@facs` attribute
* don't assume `base-uri` for `pb-facsimile` in the `facsimile.html` template
* create a new template for Shakespeare example, which uses `base-uri` feature and prefixed `pb/@facs` approach