### PR TITLE
Change @id to @class in search.html template to find facets by browse.js

### DIFF
--- a/templates/basic/templates/search.html
+++ b/templates/basic/templates/search.html
@@ -137,7 +137,7 @@
                                             <paper-checkbox name="field" value="text">Search sections</paper-checkbox>
                                             <paper-checkbox name="field" value="head">Search headings</paper-checkbox>
                                         </div>
-                                        <pb-custom-form id="facets" url="api/search/facets" subscribe="results" event="pb-results-received" emit="search"/>
+                                        <pb-custom-form class="facets" url="api/search/facets" subscribe="results" event="pb-results-received" emit="search"/>
                                     </pb-search>
                                 </div>
                             </paper-card>


### PR DESCRIPTION
The `/templates/basic/templates/search.html` file for generated applications still uses the `@id` attribute, even though there is a new `browse.js` file that searches for facets by class name, not id.