### PR TITLE
Facets: sort by output and add output to combobox

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -158,7 +158,10 @@ declare variable $config:facets := [
         "heading": "facets.feature",
         "source": "api/search/facets/feature",
         "max": 15,
-        "hierarchical": false()
+        "hierarchical": false(),
+        "output": function($label) {
+            upper-case(substring($label,1,1)) || substring($label, 2)
+        }
     },
     map {
         "dimension": "period",

--- a/modules/facets.xql
+++ b/modules/facets.xql
@@ -23,12 +23,13 @@ import module namespace config="http://www.tei-c.org/tei-simple/config" at "conf
 
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 
-declare function facets:sort($facets as map(*)?) {
+declare function facets:sort($config as map(*), $facets as map(*)?) {
     array {
         if (exists($facets)) then
             for $key in map:keys($facets)
             let $value := map:get($facets, $key)
-            order by $key ascending
+            let $sortKey := if (exists($config?output)) then $config?output($key) else $key
+            order by $sortKey ascending
             return
                 map { $key: $value }
         else
@@ -48,7 +49,7 @@ declare function facets:print-table($config as map(*), $nodes as element()+, $va
         if (map:size($facets) > 0) then
             <table>
             {
-                array:for-each(facets:sort($facets), function($entry) {
+                array:for-each(facets:sort($config, $facets), function($entry) {
                     map:for-each($entry, function($label, $freq) {
                         let $content :=
                             if (exists($config?output)) then

--- a/modules/lib/api/search.xql
+++ b/modules/lib/api/search.xql
@@ -132,9 +132,6 @@ declare function sapi:list-facets($request as map(*)) {
     })
     let $hits := session:get-attribute($config:session-prefix || ".hits")
     let $facets := ft:facets($hits, $type, ())
-    let $config := for $config in $config:facets?* where $config?dimension eq $type return $config
-
-    
     let $matches := 
         for $key in if (exists($request?parameters?value)) then $request?parameters?value else map:keys($facets)
         let $label := facets:translate($facetConfig, $lang, $key)

--- a/modules/lib/api/search.xql
+++ b/modules/lib/api/search.xql
@@ -132,12 +132,15 @@ declare function sapi:list-facets($request as map(*)) {
 
     let $hits := session:get-attribute($config:session-prefix || ".hits")
     let $facets := ft:facets($hits, $type, ())
+    let $config := for $config in $config:facets?* where $config?dimension eq $type return $config
+
     
     let $matches := 
         for $key in if (exists($request?parameters?value)) then $request?parameters?value else map:keys($facets)
+        let $text := if (exists($config?output)) then $config?output($key) else $key
         return 
             map {
-                "text": $key,
+                "text": $text,
                 "freq": $facets($key),
                 "value": $key
             } 


### PR DESCRIPTION
This PR includes some changes related to the presence of the `output` key in a facet configuration: 
- A minor change in the `facets:sort()` function so that it takes the value of `output` when sorting instead of the key.  
- A change in `sapi:list-facets()` to that the `text` key contains the value of `output`: this way the comboboxes display the same content as the list when `output` is defined.
- Just for testing purposes, `output` was added to the feature facet.