### PR TITLE
Double brackets for variables in deploy:ANT_FILE variable

### DIFF
--- a/modules/lib/api/generate.xql
+++ b/modules/lib/api/generate.xql
@@ -67,10 +67,10 @@ declare variable $deploy:ANT_FILE :=
         <property name="build.dir" value="build"/>
         <property name="scripts.dir" value="node_modules/@teipublisher/pb-components/dist"/>
 
-       <property name="fore.dir" value="${basedir}/node_modules/@jinntec/fore/dist"/>
+       <property name="fore.dir" value="${{basedir}}/node_modules/@jinntec/fore/dist"/>
 
         <target name="clean">
-            <delete dir="${build}" />
+            <delete dir="${{build}}" />
             <delete dir="resources/scripts" includes="*.js *.map" />
             <delete dir="resources/images/leaflet" />
             <delete dir="resources/images/openseadragon" />
@@ -81,11 +81,11 @@ declare variable $deploy:ANT_FILE :=
 
         <target name="prepare">
             <copy todir="resources/scripts">
-                <fileset dir="${scripts.dir}">
+                <fileset dir="${{scripts.dir}}">
                     <include name="*.js" />
                     <include name="*.map" />
                 </fileset>
-                <fileset dir="${fore.dir}">
+                <fileset dir="${{fore.dir}}">
                     <include name="*.js" />
                     <include name="*.map" />
                 </fileset>
@@ -98,7 +98,7 @@ declare variable $deploy:ANT_FILE :=
             </copy>
             <copy todir="resources/css">
                 <fileset dir="node_modules/@teipublisher/pb-components/css"/>
-                <fileset dir="${basedir}/node_modules/@jinntec/fore/resources">
+                <fileset dir="${{basedir}}/node_modules/@jinntec/fore/resources">
                     <include name="*.css"/>
                 </fileset>
             </copy>
@@ -107,7 +107,7 @@ declare variable $deploy:ANT_FILE :=
             </copy>
             
             <copy todir="resources/i18n/common">
-                <fileset dir="${scripts.dir}/../i18n/common" />
+                <fileset dir="${{scripts.dir}}/../i18n/common" />
             </copy>
         </target>
 


### PR DESCRIPTION
This fix adds double brackets to variables in the template for generated `build.xml` file.

Without this fix generated `build.xml` file contains steps like 

```xml
<fileset dir="$/../i18n/common"/>
```
instead of 
```xml
<fileset dir="${scripts.dir}/../i18n/common"/>
```.