### PR TITLE
Allow placing the annotation element after the selected text

### DIFF
--- a/resources/scripts/annotations/annotations.js
+++ b/resources/scripts/annotations/annotations.js
@@ -417,7 +417,7 @@ window.addEventListener("WebComponentsReady", () => {
 					query: selection
 				});
 			}
-			emptyElement = false;
+			elementPosition = "around";
 			if (button.classList.contains("after")) {
 				elementPosition = "after";
 			}
@@ -425,9 +425,7 @@ window.addEventListener("WebComponentsReady", () => {
 				elementPosition = "before";
 			}
 			//if class contains 'before' or 'after' value, it's an empty element
-			if (elementPosition != "around") {
-				emptyElement = true;
-			}
+			emptyElement = (elementPosition != "around");
 			window.pbEvents.emit("show-annotation", "transcription", {});
 			showForm(type);
 			text = selection;
@@ -651,7 +649,8 @@ window.addEventListener("WebComponentsReady", () => {
 		if (trackHistory) {
 			document.dispatchEvent(new CustomEvent('pb-before-save', {
 				detail: {
-					user: currentUser
+					user: currentUser,
+					export: false
 				}
 			}));
 		} else {

--- a/resources/scripts/annotations/annotations.js
+++ b/resources/scripts/annotations/annotations.js
@@ -91,6 +91,7 @@ window.addEventListener("WebComponentsReady", () => {
 	let autoSave = false;
 	let type = "";
 	let emptyElement = false;
+	let elementPosition = "around"; //default position of the annotation element to be inserted; can be also "before" (for <pb/>) or "after" (for <note>)
 	let text = "";
 	let enablePreview = true;
 	let currentEntityInfo = null;
@@ -304,7 +305,8 @@ window.addEventListener("WebComponentsReady", () => {
 				view.addAnnotation({
 					type,
 					properties: data,
-					before: emptyElement
+					before: emptyElement,
+					position : elementPosition
 				});
 			} catch (e) {
 				document.getElementById('runtime-error-dialog').show('Error', e);
@@ -416,7 +418,14 @@ window.addEventListener("WebComponentsReady", () => {
 				});
 			}
 			emptyElement = false;
+			if (button.classList.contains("after")) {
+				elementPosition = "after";
+			}
 			if (button.classList.contains("before")) {
+				elementPosition = "before";
+			}
+			//if class contains 'before' or 'after' value, it's an empty element
+			if (elementPosition != "around") {
 				emptyElement = true;
 			}
 			window.pbEvents.emit("show-annotation", "transcription", {});

--- a/templates/pages/annotate.html
+++ b/templates/pages/annotate.html
@@ -58,7 +58,7 @@
             <paper-icon-button class="annotation-action" data-i18n="[title]annotations.app" title="Apparatus" data-type="app" icon="icons:visibility" data-shortcut="⌘+⇧+v,ctrl+⇧+v" disabled="disabled"></paper-icon-button>
             <paper-icon-button class="annotation-action" data-i18n="[title]annotations.hi" title="Highlight" data-type="hi" icon="editor:format-bold" data-shortcut="⌘+⇧+h,ctrl+⇧+h" disabled="disabled"></paper-icon-button>
             <paper-icon-button class="annotation-action before" data-i18n="[title]annotations.pb" title="Page break" data-type="pb" icon="editor:format-textdirection-r-to-l" data-shortcut="⌘+⇧+b,ctrl+⇧+b" disabled="disabled"></paper-icon-button>
-            <paper-icon-button class="annotation-action before" data-i18n="[title]annotations.note" title="Note" data-type="note" icon="icons:speaker-notes" data-shortcut="⌘+⇧+f,ctrl+⇧+f" disabled="disabled"></paper-icon-button>
+            <paper-icon-button class="annotation-action after" data-i18n="[title]annotations.note" title="Note" data-type="note" icon="icons:speaker-notes" data-shortcut="⌘+⇧+f,ctrl+⇧+f" disabled="disabled"></paper-icon-button>
             <paper-icon-button class="annotation-action" data-i18n="[title]annotations.modify" title="Edit" data-type="edit" icon="editor:mode-edit" data-shortcut="⌘+⇧+m,ctrl+⇧+m" disabled="disabled"></paper-icon-button>
             <paper-icon-button id="ner-action" icon="social:group-add" data-i18n="[title]annotations.ner.title"></paper-icon-button>
         </span>


### PR DESCRIPTION
In the annotation view, inserted `<pb>` and `<note>` elements are placed before the selected text.

In the case of notes, however, it's common to insert them after the commented text.

I added new property `position` to the data passed to the function [`addAnnotation()`](https://github.com/eeditiones/tei-publisher-components/blob/d58831d36aa0eea693e9df76310ea0bb997d9d75/src/pb-view-annotate.js#L627) that is defined in the `pb-view-annotate.js` web component,

The  default value of the `position` property is `around` and can be changed by specifying the value `after` in the `@class` attribute of the button for the element, for example

```xml
<paper-icon-button class="annotation-action after" data-i18n="[title]annotations.note" title="Note" ...></paper-icon-button>
```

In the similar way, the value `before` in the `@class` attribute is used now for elements that should be placed after the selected text.

To be functional this change must be made at the same time as the change of the `pb-view-annotate.js` web component.

See parallel required [pull request](https://github.com/eeditiones/tei-publisher-components/pull/180) in the Web Components for TEI Publisher.